### PR TITLE
Fixed typos on Yet Another Messaging Service line

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -57,7 +57,7 @@
 \cventry{Academic}{Yet Another Messaging Service}{}{}{}{
     \begin{itemize}
         \item Slack-like clone written in Typescript and React, and Electron for the client.
-        \item Socket.io was used for message communications, and MongoDB for persistant storage. 
+        \item Used Socket.io for message communications, and MongoDB for persistent storage. 
     \end{itemize}
 }
 


### PR DESCRIPTION
- `s/persistant/persistent/`
- Made a passive sentence active